### PR TITLE
Implement per-planet customizable geode ores

### DIFF
--- a/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
+++ b/src/main/java/zmaster587/advancedRocketry/dimension/DimensionProperties.java
@@ -238,6 +238,7 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 	public double rotationalPhi;
 	public OreGenProperties oreProperties = null;
 	public List<ItemStack> laserDrillOres;
+	public List<String> geodeOres;
 	// The parsing of laserOreDrills is destructive of the actual oredict entries, so we keep a copy of the raw data around for XML writing
 	public String laserDrillOresRaw;
 	public String customIcon;
@@ -296,6 +297,7 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 		fillerBlock = null;
 
 		laserDrillOres = new ArrayList<>();
+		geodeOres = new ArrayList<>();
 
 		allowedBiomes = new LinkedList<BiomeManager.BiomeEntry>();
 		terraformedBiomes = new LinkedList<BiomeManager.BiomeEntry>();
@@ -1425,6 +1427,14 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 				laserDrillOres.add(new ItemStack((NBTTagCompound) entry));
 			}
 		}
+		if(nbt.hasKey("geodeOres")) {
+			geodeOres.clear();
+			list = nbt.getTagList("geodeOres", NBT.TAG_STRING);
+			for(NBTBase entry: list) {
+				assert entry instanceof NBTTagString;
+				geodeOres.add(((NBTTagString) entry).getString());
+			}
+		}
 
 		if(nbt.hasKey("laserDrillOresRaw")) {
 			laserDrillOresRaw = nbt.getString("laserDrillOresRaw");
@@ -1608,6 +1618,14 @@ public class DimensionProperties implements Cloneable, IDimensionProperties {
 
 		if(laserDrillOresRaw != null) {
 			nbt.setTag("laserDrillOresRaw",new NBTTagString(laserDrillOresRaw));
+		}
+
+		if(!geodeOres.isEmpty()) {
+			list = new NBTTagList();
+			for(String ore: geodeOres) {
+				list.appendTag(new NBTTagString(ore));
+			}
+			nbt.setTag("geodeOres",list);
 		}
 
 		nbt.setInteger("starId", starId);

--- a/src/main/java/zmaster587/advancedRocketry/util/XMLPlanetLoader.java
+++ b/src/main/java/zmaster587/advancedRocketry/util/XMLPlanetLoader.java
@@ -92,6 +92,7 @@ public class XMLPlanetLoader {
 	private static final String ELEMENT_GENTYPE = "genType";
 	private static final String ELEMENT_OREGEN = "oreGen";
 	private static final String ELEMENT_LASER_DRILL_ORES = "laserDrillOres";
+	private static final String ELEMENT_GEODE_ORES = "geodeOres";
 	private static final String ELEMENT_BIOMEIDS = "biomeIds";
 	private static final String ELEMENT_ARTIFACT = "artifact";
 	private static final String ELEMENT_OCEANBLOCK = "oceanBlock";
@@ -521,6 +522,14 @@ public class XMLPlanetLoader {
 					}
 				}
 			}
+			else if(planetPropertyNode.getNodeName().equalsIgnoreCase(ELEMENT_GEODE_ORES)) {
+				String[] entries = planetPropertyNode.getTextContent().split(",");
+				for (String entry : entries) {
+					if(OreDictionary.doesOreNameExist(entry.trim())) {
+						properties.geodeOres.add(entry);
+					}
+				}
+			}
 			else if(planetPropertyNode.getNodeName().equalsIgnoreCase(ELEMENT_GENTYPE)) {
 				try {
 					properties.setGenType(Integer.parseInt(planetPropertyNode.getTextContent()));
@@ -947,6 +956,13 @@ public class XMLPlanetLoader {
 		}
 		if(properties.laserDrillOresRaw != null) {
 			nodePlanet.appendChild(createTextNode(doc, ELEMENT_LASER_DRILL_ORES, properties.laserDrillOresRaw));
+		}
+		if(!properties.geodeOres.isEmpty()) {
+			StringJoiner joiner = new StringJoiner(",");
+			for(String ore: properties.geodeOres) {
+				joiner.add(ore);
+			}
+			nodePlanet.appendChild(createTextNode(doc, ELEMENT_GEODE_ORES, joiner.toString()));
 		}
 
 		if(properties.isDecorationOverridden())


### PR DESCRIPTION
This allows geode ore generation to be customized per-planet using the `geodeOres` XML tag. Format is a comma separated list of ore dictionary entries